### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           wget $FIRMWARE_URL -O openwrt.tar.gz
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           FIRMWARE: openwrt.tar.gz
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore